### PR TITLE
Make start name unique

### DIFF
--- a/template/masterdeployrg.json
+++ b/template/masterdeployrg.json
@@ -16,9 +16,15 @@
         },
         "deploymentRGArray": {
             "type": "array"
+        },
+        "guidValue": {
+            "type": "string",
+            "defaultValue": "[newGuid()]"
         }
     },
     "variables": {
+        "startName": "[concat('start-', parameters('guidValue'))]",
+        "jsonStartName": "[concat('\"', variables('startName'), '\"')]"
     },
     "resources": [
         {
@@ -40,7 +46,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2018-05-01",
             "resourceGroup": "[parameters('deploymentRGArray')[copyIndex()].resourceGroup]",
-            "dependsOn": ["[if(contains(parameters('deploymentRGArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentRGArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json('\"start\"'))]"],
+            "dependsOn": ["[if(contains(parameters('deploymentRGArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentRGArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json(variables('jsonStartName')))]"],
             "copy": {
                 "name": "obj",
                 "count": "[length(parameters('deploymentRGArray'))]"

--- a/template/masterdeploysub.json
+++ b/template/masterdeploysub.json
@@ -45,7 +45,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2018-05-01",
             "location": "[parameters('deploymentSubArray')[copyIndex()].location]",
-            "dependsOn": ["[if(contains(parameters('deploymentSubArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentSubArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json(variables('startName')))]"],
+            "dependsOn": ["[if(contains(parameters('deploymentSubArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentSubArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json(concat('\"', variables('startName'), '\"')))]"],
             "copy": {
                 "name": "obj",
                 "count": "[length(parameters('deploymentSubArray'))]"

--- a/template/masterdeploysub.json
+++ b/template/masterdeploysub.json
@@ -16,14 +16,19 @@
         },
         "deploymentSubArray": {
             "type": "array"
+        },
+        "guidValue": {
+            "type": "string",
+            "defaultValue": "[newGuid()]"
         }
     },
     "variables": {
-    },
+        "startName": "[concat('start-', parameters('guidValue'))]"
+     },
     "resources": [
         {
             "apiVersion": "2018-05-01",
-            "name": "start",
+            "name": "[variables('startName')]",
             "type": "Microsoft.Resources/deployments",
             "location": "canadacentral",
             "properties": {
@@ -40,7 +45,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2018-05-01",
             "location": "[parameters('deploymentSubArray')[copyIndex()].location]",
-            "dependsOn": ["[if(contains(parameters('deploymentSubArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentSubArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json('\"start\"'))]"],
+            "dependsOn": ["[if(contains(parameters('deploymentSubArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentSubArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json(variables('startName')))]"],
             "copy": {
                 "name": "obj",
                 "count": "[length(parameters('deploymentSubArray'))]"

--- a/template/masterdeploysub.json
+++ b/template/masterdeploysub.json
@@ -23,7 +23,8 @@
         }
     },
     "variables": {
-        "startName": "[concat('start-', parameters('guidValue'))]"
+        "startName": "[concat('start-', parameters('guidValue'))]",
+        "jsonStartName": "[concat('\"', variables('startName'), '\"')]"
      },
     "resources": [
         {
@@ -45,7 +46,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2018-05-01",
             "location": "[parameters('deploymentSubArray')[copyIndex()].location]",
-            "dependsOn": ["[if(contains(parameters('deploymentSubArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentSubArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json(concat('\"', variables('startName'), '\"')))]"],
+            "dependsOn": ["[if(contains(parameters('deploymentSubArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentSubArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json(variables('jsonStartName')))]"],
             "copy": {
                 "name": "obj",
                 "count": "[length(parameters('deploymentSubArray'))]"

--- a/template/masterdeploysubrg.json
+++ b/template/masterdeploysubrg.json
@@ -19,9 +19,16 @@
         },
         "deploymentRGArray": {
             "type": "array"
+        },
+        "guidValue": {
+            "type": "string",
+            "defaultValue": "[newGuid()]"
         }
     },
-    "variables": {},
+    "variables": {
+        "startName": "[concat('start-', parameters('guidValue'))]",
+        "jsonStartName": "[concat('\"', variables('startName'), '\"')]"
+    },
     "resources": [
         {
             "apiVersion": "2018-05-01",
@@ -42,7 +49,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2018-05-01",
             "location": "[parameters('deploymentSubArray')[copyIndex()].location]",
-            "dependsOn": ["[if(contains(parameters('deploymentSubArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentSubArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json('\"start\"'))]"],
+            "dependsOn": ["[if(contains(parameters('deploymentSubArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentSubArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json(variables('jsonStartName')))]"],
             "copy": {
                 "name": "objSub",
                 "count": "[length(parameters('deploymentSubArray'))]"
@@ -64,7 +71,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2018-05-01",
             "resourceGroup": "[parameters('deploymentRGArray')[copyIndex()].resourceGroup]",
-            "dependsOn": ["[if(contains(parameters('deploymentRGArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentRGArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json('\"start\"'))]"],
+            "dependsOn": ["[if(contains(parameters('deploymentRGArray')[copyIndex()], 'dependsOn'), json(replace(replace(string(parameters('deploymentRGArray')[copyIndex()].dependsOn), '[', ''), ']', '')), json(variables('jsonStartName')))]"],
             "copy": {
                 "name": "objRG",
                 "count": "[length(parameters('deploymentRGArray'))]"


### PR DESCRIPTION
Prevent issues with concurrent deployment running with same name at subscription level